### PR TITLE
Feat/multiple cboms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY --chown=0:0 src/main/resources/java/scan/*.jar /java/scan/
 
 ENV CBOMKIT_JAVA_JAR_DIR="/java/scan/"
 
-CMD ["java","-Xmx1g","-jar","/CBOMkit-action.jar"]
+CMD ["java","-Xmx16g","-jar","/CBOMkit-action.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY --chown=0:0 src/main/resources/java/scan/*.jar /java/scan/
 
 ENV CBOMKIT_JAVA_JAR_DIR="/java/scan/"
 
-CMD ["java","-jar","/CBOMkit-action.jar"]
+CMD ["java","-Xmx1g","-jar","/CBOMkit-action.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY --chown=0:0 src/main/resources/java/scan/*.jar /java/scan/
 
 ENV CBOMKIT_JAVA_JAR_DIR="/java/scan/"
 
-CMD ["java","-Xmx16g","-jar","/CBOMkit-action.jar"]
+CMD ["java","-Xmx8g","-jar","/CBOMkit-action.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY --chown=0:0 src/main/resources/java/scan/*.jar /java/scan/
 
 ENV CBOMKIT_JAVA_JAR_DIR="/java/scan/"
 
-CMD ["java","-Xmx8g","-jar","/CBOMkit-action.jar"]
+CMD ["java","-Xmx16g","-jar","/CBOMkit-action.jar"]

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: 'CBOMkit-action'
 description: 'Generate CBOM from source code'
 outputs:
-  filename:
-    description: 'CBOM file name'
+  pattern:
+    description: 'CBOM file name pattern'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
             <artifactId>maven-model</artifactId>
             <version>3.9.9</version>
         </dependency>
+        <dependency>
+            <groupId>org.tomlj</groupId>
+            <artifactId>tomlj</artifactId>
+            <version>1.1.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
             <artifactId>sonar-plugin-api-impl</artifactId>
             <version>${sonar.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+            <version>3.9.9</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/pqca/BomGenerator.java
+++ b/src/main/java/org/pqca/BomGenerator.java
@@ -39,9 +39,7 @@ import org.pqca.errors.CouldNotLoadJavaJars;
 import org.pqca.indexing.JavaIndexService;
 import org.pqca.indexing.ProjectModule;
 import org.pqca.indexing.PythonIndexService;
-import org.pqca.packages.MavenPackageFinderService;
 import org.pqca.packages.PackageMetadata;
-import org.pqca.packages.PythonPackageFinderService;
 import org.pqca.scanning.java.JavaScannerService;
 import org.pqca.scanning.python.PythonScannerService;
 import org.slf4j.Logger;
@@ -64,21 +62,21 @@ public class BomGenerator {
         final List<ProjectModule> javaProjectModules = javaIndexService.index();
 
         final List<File> javaJars = getJavaJars();
-        final MavenPackageFinderService packageFinder =
-                new MavenPackageFinderService(projectDirectory);
-        for (PackageMetadata pm : packageFinder.findPackages()) {
-            LOG.info("Scanning maven package {}", pm.packageDir());
-            final List<ProjectModule> packageModules =
-                    getPackageModules(javaProjectModules, pm.packageDir());
-            if (!packageModules.isEmpty()) {
-                final JavaScannerService javaScannerService =
-                        new JavaScannerService(javaJars, pm.packageDir());
-                final Bom javaBom = javaScannerService.scan(packageModules);
-                writeBom(pm, javaBom);
-            } else {
-                LOG.info("No java source code to scan.");
-            }
-        }
+        // final MavenPackageFinderService packageFinder =
+        //         new MavenPackageFinderService(projectDirectory);
+        // for (PackageMetadata pm : packageFinder.findPackages()) {
+        //     LOG.info("Scanning maven package {}", pm.packageDir());
+        //     final List<ProjectModule> packageModules =
+        //             getPackageModules(javaProjectModules, pm.packageDir());
+        //     if (!packageModules.isEmpty()) {
+        //         final JavaScannerService javaScannerService =
+        //                 new JavaScannerService(javaJars, pm.packageDir());
+        //         final Bom javaBom = javaScannerService.scan(packageModules);
+        //         writeBom(pm, javaBom);
+        //     } else {
+        //         LOG.info("No java source code to scan.");
+        //     }
+        // }
 
         final JavaScannerService javaScannerService =
                 new JavaScannerService(javaJars, projectDirectory);
@@ -90,21 +88,21 @@ public class BomGenerator {
         final PythonIndexService pythonIndexService = new PythonIndexService(projectDirectory);
         final List<ProjectModule> pythonProjectModules = pythonIndexService.index();
 
-        final PythonPackageFinderService packageFinder =
-                new PythonPackageFinderService(projectDirectory);
-        for (PackageMetadata pm : packageFinder.findPackages()) {
-            LOG.info("Scanning python package {}", pm.packageDir());
-            final List<ProjectModule> packageModules =
-                    getPackageModules(pythonProjectModules, pm.packageDir());
-            if (!packageModules.isEmpty()) {
-                final PythonScannerService pythonScannerService =
-                        new PythonScannerService(pm.packageDir());
-                final Bom pythonBom = pythonScannerService.scan(packageModules);
-                writeBom(pm, pythonBom);
-            } else {
-                LOG.info("No python source code to scan.");
-            }
-        }
+        // final PythonPackageFinderService packageFinder =
+        //         new PythonPackageFinderService(projectDirectory);
+        // for (PackageMetadata pm : packageFinder.findPackages()) {
+        //     LOG.info("Scanning python package {}", pm.packageDir());
+        //     final List<ProjectModule> packageModules =
+        //             getPackageModules(pythonProjectModules, pm.packageDir());
+        //     if (!packageModules.isEmpty()) {
+        //         final PythonScannerService pythonScannerService =
+        //                 new PythonScannerService(pm.packageDir());
+        //         final Bom pythonBom = pythonScannerService.scan(packageModules);
+        //         writeBom(pm, pythonBom);
+        //     } else {
+        //         LOG.info("No python source code to scan.");
+        //     }
+        // }
 
         final PythonScannerService pythonScannerService =
                 new PythonScannerService(projectDirectory);

--- a/src/main/java/org/pqca/BomGenerator.java
+++ b/src/main/java/org/pqca/BomGenerator.java
@@ -19,6 +19,7 @@
  */
 package org.pqca;
 
+import com.ibm.output.IOutputFileFactory;
 import jakarta.annotation.Nonnull;
 import java.io.File;
 import java.io.FileFilter;
@@ -75,6 +76,9 @@ public class BomGenerator {
                         new JavaScannerService(javaJars, pm.packageDir());
                 final Bom javaBom = javaScannerService.scan(packageModules);
                 writeBom(pm, javaBom);
+                final com.ibm.plugin.ScannerManager scannerMgr =
+                        new com.ibm.plugin.ScannerManager(IOutputFileFactory.DEFAULT);
+                scannerMgr.reset();
             } else {
                 LOG.info("No java source code to scan.");
             }
@@ -101,6 +105,9 @@ public class BomGenerator {
                         new PythonScannerService(pm.packageDir());
                 final Bom pythonBom = pythonScannerService.scan(packageModules);
                 writeBom(pm, pythonBom);
+                final com.ibm.plugin.ScannerManager scannerMgr =
+                        new com.ibm.plugin.ScannerManager(IOutputFileFactory.DEFAULT);
+                scannerMgr.reset();
             } else {
                 LOG.info("No python source code to scan.");
             }

--- a/src/main/java/org/pqca/BomGenerator.java
+++ b/src/main/java/org/pqca/BomGenerator.java
@@ -39,7 +39,9 @@ import org.pqca.errors.CouldNotLoadJavaJars;
 import org.pqca.indexing.JavaIndexService;
 import org.pqca.indexing.ProjectModule;
 import org.pqca.indexing.PythonIndexService;
+import org.pqca.packages.MavenPackageFinderService;
 import org.pqca.packages.PackageMetadata;
+import org.pqca.packages.PythonPackageFinderService;
 import org.pqca.scanning.java.JavaScannerService;
 import org.pqca.scanning.python.PythonScannerService;
 import org.slf4j.Logger;
@@ -62,21 +64,21 @@ public class BomGenerator {
         final List<ProjectModule> javaProjectModules = javaIndexService.index();
 
         final List<File> javaJars = getJavaJars();
-        // final MavenPackageFinderService packageFinder =
-        //         new MavenPackageFinderService(projectDirectory);
-        // for (PackageMetadata pm : packageFinder.findPackages()) {
-        //     LOG.info("Scanning maven package {}", pm.packageDir());
-        //     final List<ProjectModule> packageModules =
-        //             getPackageModules(javaProjectModules, pm.packageDir());
-        //     if (!packageModules.isEmpty()) {
-        //         final JavaScannerService javaScannerService =
-        //                 new JavaScannerService(javaJars, pm.packageDir());
-        //         final Bom javaBom = javaScannerService.scan(packageModules);
-        //         writeBom(pm, javaBom);
-        //     } else {
-        //         LOG.info("No java source code to scan.");
-        //     }
-        // }
+        final MavenPackageFinderService packageFinder =
+                new MavenPackageFinderService(projectDirectory);
+        for (PackageMetadata pm : packageFinder.findPackages()) {
+            LOG.info("Scanning maven package {}", pm.packageDir());
+            final List<ProjectModule> packageModules =
+                    getPackageModules(javaProjectModules, pm.packageDir());
+            if (!packageModules.isEmpty()) {
+                final JavaScannerService javaScannerService =
+                        new JavaScannerService(javaJars, pm.packageDir());
+                final Bom javaBom = javaScannerService.scan(packageModules);
+                writeBom(pm, javaBom);
+            } else {
+                LOG.info("No java source code to scan.");
+            }
+        }
 
         final JavaScannerService javaScannerService =
                 new JavaScannerService(javaJars, projectDirectory);
@@ -88,21 +90,21 @@ public class BomGenerator {
         final PythonIndexService pythonIndexService = new PythonIndexService(projectDirectory);
         final List<ProjectModule> pythonProjectModules = pythonIndexService.index();
 
-        // final PythonPackageFinderService packageFinder =
-        //         new PythonPackageFinderService(projectDirectory);
-        // for (PackageMetadata pm : packageFinder.findPackages()) {
-        //     LOG.info("Scanning python package {}", pm.packageDir());
-        //     final List<ProjectModule> packageModules =
-        //             getPackageModules(pythonProjectModules, pm.packageDir());
-        //     if (!packageModules.isEmpty()) {
-        //         final PythonScannerService pythonScannerService =
-        //                 new PythonScannerService(pm.packageDir());
-        //         final Bom pythonBom = pythonScannerService.scan(packageModules);
-        //         writeBom(pm, pythonBom);
-        //     } else {
-        //         LOG.info("No python source code to scan.");
-        //     }
-        // }
+        final PythonPackageFinderService packageFinder =
+                new PythonPackageFinderService(projectDirectory);
+        for (PackageMetadata pm : packageFinder.findPackages()) {
+            LOG.info("Scanning python package {}", pm.packageDir());
+            final List<ProjectModule> packageModules =
+                    getPackageModules(pythonProjectModules, pm.packageDir());
+            if (!packageModules.isEmpty()) {
+                final PythonScannerService pythonScannerService =
+                        new PythonScannerService(pm.packageDir());
+                final Bom pythonBom = pythonScannerService.scan(packageModules);
+                writeBom(pm, pythonBom);
+            } else {
+                LOG.info("No python source code to scan.");
+            }
+        }
 
         final PythonScannerService pythonScannerService =
                 new PythonScannerService(projectDirectory);

--- a/src/main/java/org/pqca/BomGenerator.java
+++ b/src/main/java/org/pqca/BomGenerator.java
@@ -20,6 +20,7 @@
 package org.pqca;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileWriter;
@@ -58,8 +59,7 @@ public class BomGenerator {
         this.projectDirectory = projectDirectory;
     }
 
-    @Nonnull
-    public Bom generateJavaBoms() throws CouldNotLoadJavaJars {
+    @Nullable public Bom generateJavaBoms() throws CouldNotLoadJavaJars {
         final JavaIndexService javaIndexService = new JavaIndexService(projectDirectory);
         final List<ProjectModule> javaProjectModules = javaIndexService.index();
 
@@ -78,13 +78,13 @@ public class BomGenerator {
             }
         }
 
-        final JavaScannerService javaScannerService =
-                new JavaScannerService(javaJars, projectDirectory);
-        return javaScannerService.scan(javaProjectModules);
+        // final JavaScannerService javaScannerService =
+        //         new JavaScannerService(javaJars, projectDirectory);
+        // return javaScannerService.scan(javaProjectModules);
+        return null;
     }
 
-    @Nonnull
-    public Bom generatePythonBoms() {
+    @Nullable public Bom generatePythonBoms() {
         final PythonIndexService pythonIndexService = new PythonIndexService(projectDirectory);
         final List<ProjectModule> pythonProjectModules = pythonIndexService.index();
 
@@ -102,12 +102,16 @@ public class BomGenerator {
             }
         }
 
-        final PythonScannerService pythonScannerService =
-                new PythonScannerService(projectDirectory);
-        return pythonScannerService.scan(pythonProjectModules);
+        // final PythonScannerService pythonScannerService =
+        //         new PythonScannerService(projectDirectory);
+        // return pythonScannerService.scan(pythonProjectModules);
+        return null;
     }
 
     private List<ProjectModule> getPackageModules(List<ProjectModule> allModules, File packageDir) {
+        LOG.info("Searching for " + packageDir.toString());
+        allModules.forEach(
+                pm -> LOG.info(projectDirectory.toPath().resolve(pm.identifier()).toString()));
         return allModules.stream()
                 .filter(
                         pm ->

--- a/src/main/java/org/pqca/BomGenerator.java
+++ b/src/main/java/org/pqca/BomGenerator.java
@@ -79,7 +79,7 @@ public class BomGenerator {
         }
 
         // final JavaScannerService javaScannerService =
-        //         new JavaScannerService(javaJars, projectDirectory);
+        // new JavaScannerService(javaJars, projectDirectory);
         // return javaScannerService.scan(javaProjectModules);
         return null;
     }
@@ -103,7 +103,7 @@ public class BomGenerator {
         }
 
         // final PythonScannerService pythonScannerService =
-        //         new PythonScannerService(projectDirectory);
+        // new PythonScannerService(projectDirectory);
         // return pythonScannerService.scan(pythonProjectModules);
         return null;
     }
@@ -115,10 +115,10 @@ public class BomGenerator {
         return allModules.stream()
                 .filter(
                         pm ->
-                                packageDir
+                                projectDirectory
                                         .toPath()
-                                        .startsWith(
-                                                projectDirectory.toPath().resolve(pm.identifier())))
+                                        .resolve(pm.identifier())
+                                        .startsWith(packageDir.toPath()))
                 .toList();
     }
 

--- a/src/main/java/org/pqca/BomGenerator.java
+++ b/src/main/java/org/pqca/BomGenerator.java
@@ -1,0 +1,180 @@
+/*
+ * CBOMkit-action
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pqca;
+
+import jakarta.annotation.Nonnull;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import org.cyclonedx.Version;
+import org.cyclonedx.exception.GeneratorException;
+import org.cyclonedx.generators.BomGeneratorFactory;
+import org.cyclonedx.generators.json.BomJsonGenerator;
+import org.cyclonedx.model.Bom;
+import org.cyclonedx.model.Metadata;
+import org.cyclonedx.model.OrganizationalEntity;
+import org.cyclonedx.model.Service;
+import org.cyclonedx.model.metadata.ToolInformation;
+import org.pqca.errors.CouldNotLoadJavaJars;
+import org.pqca.indexing.JavaIndexService;
+import org.pqca.indexing.ProjectModule;
+import org.pqca.indexing.PythonIndexService;
+import org.pqca.packages.MavenPackageFinderService;
+import org.pqca.packages.PackageMetadata;
+import org.pqca.packages.PythonPackageFinderService;
+import org.pqca.scanning.java.JavaScannerService;
+import org.pqca.scanning.python.PythonScannerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BomGenerator {
+    private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+    private static final String ACTION_NAME = "CBOMkit-action";
+    private static final String ACTION_ORG = "PQCA";
+
+    @Nonnull private final File projectDirectory;
+
+    public BomGenerator(@Nonnull File projectDirectory) {
+        this.projectDirectory = projectDirectory;
+    }
+
+    @Nonnull
+    public Bom generateJavaBoms() throws CouldNotLoadJavaJars {
+        final JavaIndexService javaIndexService = new JavaIndexService(projectDirectory);
+        final List<ProjectModule> javaProjectModules = javaIndexService.index();
+
+        final List<File> javaJars = getJavaJars();
+        final MavenPackageFinderService packageFinder =
+                new MavenPackageFinderService(projectDirectory);
+        for (PackageMetadata pm : packageFinder.findPackages()) {
+            LOG.info("Java package is: {}", pm.packageDir());
+            final List<ProjectModule> packageModules =
+                    getPackageModules(javaProjectModules, pm.packageDir());
+            if (!packageModules.isEmpty()) {
+                final JavaScannerService javaScannerService =
+                        new JavaScannerService(javaJars, pm.packageDir());
+                final Bom javaBom = javaScannerService.scan(packageModules);
+                writeBom(pm, javaBom);
+            }
+        }
+
+        final JavaScannerService javaScannerService =
+                new JavaScannerService(javaJars, projectDirectory);
+        return javaScannerService.scan(javaProjectModules);
+    }
+
+    @Nonnull
+    public Bom generatePythonBoms() {
+        final PythonIndexService pythonIndexService = new PythonIndexService(projectDirectory);
+        final List<ProjectModule> pythonProjectModules = pythonIndexService.index();
+
+        final PythonPackageFinderService packageFinder =
+                new PythonPackageFinderService(projectDirectory);
+        for (PackageMetadata pm : packageFinder.findPackages()) {
+            LOG.info("Python package is: {}", pm.packageDir());
+            final List<ProjectModule> packageModules =
+                    getPackageModules(pythonProjectModules, pm.packageDir());
+            if (!packageModules.isEmpty()) {
+                final PythonScannerService pythonScannerService =
+                        new PythonScannerService(pm.packageDir());
+                final Bom pythonBom = pythonScannerService.scan(packageModules);
+                writeBom(pm, pythonBom);
+            }
+        }
+
+        final PythonScannerService pythonScannerService =
+                new PythonScannerService(projectDirectory);
+        return pythonScannerService.scan(pythonProjectModules);
+    }
+
+    private List<ProjectModule> getPackageModules(List<ProjectModule> allModules, File packageDir) {
+        return allModules.stream()
+                .filter(
+                        pm ->
+                                packageDir
+                                        .toPath()
+                                        .startsWith(
+                                                projectDirectory.toPath().resolve(pm.identifier())))
+                .toList();
+    }
+
+    public void writeBom(Bom bom) {
+        writeBom(new PackageMetadata(projectDirectory, null, null, null), bom);
+    }
+
+    private static void writeBom(PackageMetadata packageMetadata, Bom bom) {
+        bom.setMetadata(generateMetadata());
+
+        final BomJsonGenerator bomGenerator =
+                BomGeneratorFactory.createJson(Version.VERSION_16, bom);
+
+        try {
+            String bomString = bomGenerator.toJsonString();
+            if (bomString == null) {
+                LOG.error("Empty CBOM");
+            }
+
+            final String fileName = packageMetadata.getCbomFileName();
+            LOG.info(
+                    "Writing cbom {} with {} components",
+                    fileName,
+                    bom.getComponents() == null ? 0 : bom.getComponents().size());
+            try (FileWriter writer = new FileWriter(fileName)) {
+                writer.write(bomString);
+            }
+        } catch (IOException | GeneratorException e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    private static Metadata generateMetadata() {
+        final Metadata metadata = new Metadata();
+        metadata.setTimestamp(new Date());
+
+        final ToolInformation scannerInfo = new ToolInformation();
+        final Service scannerService = new Service();
+        scannerService.setName(ACTION_NAME);
+
+        final OrganizationalEntity organization = new OrganizationalEntity();
+        organization.setName(ACTION_ORG);
+        scannerService.setProvider(organization);
+        scannerInfo.setServices(List.of(scannerService));
+        metadata.setToolChoice(scannerInfo);
+
+        return metadata;
+    }
+
+    @Nonnull
+    private static List<File> getJavaJars() throws CouldNotLoadJavaJars {
+        final String directoryPath = System.getenv("CBOMKIT_JAVA_JAR_DIR");
+        final File directory = new File(directoryPath);
+        final FileFilter jarFilter =
+                file -> file.isFile() && file.getName().toLowerCase().endsWith(".jar");
+        final File[] jars = directory.listFiles(jarFilter);
+        if (jars == null || jars.length == 0) {
+            throw new CouldNotLoadJavaJars(directory);
+        }
+        LOG.info("Loaded {} jars", jars.length);
+        return List.of(jars);
+    }
+}

--- a/src/main/java/org/pqca/BomGenerator.java
+++ b/src/main/java/org/pqca/BomGenerator.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 import org.cyclonedx.Version;
@@ -190,14 +191,16 @@ public class BomGenerator {
         if (commit != null) {
             final Property commitProperty = new Property();
             commitProperty.setName("commit");
-            commitProperty.setValue(commit);
+            commitProperty.setValue(commit.substring(0, 7));
             metadata.addProperty(commitProperty);
         }
 
         if (!packageMetadata.packageDir().equals(projectDirectory)) {
+            final Path relPackageDir =
+                    packageMetadata.packageDir().toPath().relativize(projectDirectory.toPath());
             final Property packageFolderProperty = new Property();
             packageFolderProperty.setName("packageFolder");
-            packageFolderProperty.setValue(packageMetadata.packageDir().toString());
+            packageFolderProperty.setValue(relPackageDir.toString());
             metadata.addProperty(packageFolderProperty);
         }
 

--- a/src/main/java/org/pqca/BomGenerator.java
+++ b/src/main/java/org/pqca/BomGenerator.java
@@ -171,11 +171,12 @@ public class BomGenerator {
         scannerInfo.setServices(List.of(scannerService));
         metadata.setToolChoice(scannerInfo);
 
+        final String gitServer = System.getenv("GITHUB_SERVER_URL");
         final String gitUrl = System.getenv("GITHUB_REPOSITORY");
-        if (gitUrl != null) {
+        if (gitServer != null && gitUrl != null) {
             final Property gitUrlProperty = new Property();
             gitUrlProperty.setName("gitUrl");
-            gitUrlProperty.setValue(gitUrl);
+            gitUrlProperty.setValue(gitServer + "/" + gitUrl);
             metadata.addProperty(gitUrlProperty);
         }
 

--- a/src/main/java/org/pqca/BomGenerator.java
+++ b/src/main/java/org/pqca/BomGenerator.java
@@ -198,7 +198,7 @@ public class BomGenerator {
 
         if (!packageMetadata.packageDir().equals(projectDirectory)) {
             final Path relPackageDir =
-                    packageMetadata.packageDir().toPath().relativize(projectDirectory.toPath());
+                    projectDirectory.toPath().relativize(packageMetadata.packageDir().toPath());
             final Property packageFolderProperty = new Property();
             packageFolderProperty.setName("packageFolder");
             packageFolderProperty.setValue(relPackageDir.toString());

--- a/src/main/java/org/pqca/BomGenerator.java
+++ b/src/main/java/org/pqca/BomGenerator.java
@@ -199,10 +199,10 @@ public class BomGenerator {
         if (!packageMetadata.packageDir().equals(projectDirectory)) {
             final Path relPackageDir =
                     projectDirectory.toPath().relativize(packageMetadata.packageDir().toPath());
-            final Property packageFolderProperty = new Property();
-            packageFolderProperty.setName("packageFolder");
-            packageFolderProperty.setValue(relPackageDir.toString());
-            metadata.addProperty(packageFolderProperty);
+            final Property subFolderProperty = new Property();
+            subFolderProperty.setName("subfolder");
+            subFolderProperty.setValue(relPackageDir.toString());
+            metadata.addProperty(subFolderProperty);
         }
 
         return metadata;

--- a/src/main/java/org/pqca/Main.java
+++ b/src/main/java/org/pqca/Main.java
@@ -25,6 +25,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
@@ -38,6 +39,11 @@ public class Main {
     private static final Logger LOG = LoggerFactory.getLogger(Main.class);
 
     public static void main(@Nonnull String[] args) {
+        Map<String, String> env = System.getenv();
+        for (String envName : env.keySet()) {
+            LOG.info("{}={}", envName, env.get(envName));
+        }
+
         final String workspace = System.getenv("GITHUB_WORKSPACE");
         final File projectDirectory = new File(workspace);
         final BomGenerator bomGenerator = new BomGenerator(projectDirectory);

--- a/src/main/java/org/pqca/Main.java
+++ b/src/main/java/org/pqca/Main.java
@@ -78,6 +78,10 @@ public class Main {
                     // java
                     final List<ProjectModule> javaProjectModules =
                             javaIndexService.index(packagePath);
+                    if (javaProjectModules.isEmpty()) {
+                        LOG.info("Skipping - no projects found");
+                        continue;
+                    }
                     final JavaScannerService javaScannerService =
                             new JavaScannerService(javaJars, packagePath.toFile());
                     final Bom javaBom = javaScannerService.scan(null, javaProjectModules);
@@ -112,7 +116,7 @@ public class Main {
                         .map(
                                 pm ->
                                         String.format(
-                                                "cbom_{}_{}_{}.json",
+                                                "cbom_%s_%s_%s.json",
                                                 pm.namespace(),
                                                 pm.name(),
                                                 pm.version()))

--- a/src/main/java/org/pqca/Main.java
+++ b/src/main/java/org/pqca/Main.java
@@ -43,11 +43,11 @@ public class Main {
         final BomGenerator bomGenerator = new BomGenerator(projectDirectory);
 
         try {
-            /*Bom javaBom = */ bomGenerator.generateJavaBoms();
-            /*Bom pythonBom = */ bomGenerator.generatePythonBoms();
+            Bom javaBom = bomGenerator.generateJavaBoms();
+            Bom pythonBom = bomGenerator.generatePythonBoms();
 
-            // Bom consolidatedBom = createCombinedBom(List.of(javaBom, pythonBom));
-            // bomGenerator.writeBom(consolidatedBom);
+            Bom consolidatedBom = createCombinedBom(List.of(javaBom, pythonBom));
+            bomGenerator.writeBom(consolidatedBom);
         } catch (CouldNotLoadJavaJars e) {
             LOG.error(e.getMessage(), e);
         }

--- a/src/main/java/org/pqca/Main.java
+++ b/src/main/java/org/pqca/Main.java
@@ -93,6 +93,15 @@ public class Main {
             }
         } catch (CouldNotLoadJavaJars e) {
             LOG.error(e.getMessage(), e);
+            return;
+        }
+
+        // set output var
+        final String githubOutput = System.getenv("GITHUB_OUTPUT");
+        try (final FileWriter outPutVarFileWriter = new FileWriter(githubOutput, true)) {
+            outPutVarFileWriter.write("pattern=cbom*.json\n");
+        } catch (IOException e) {
+            LOG.error(e.getMessage(), e);
         }
     }
 

--- a/src/main/java/org/pqca/Main.java
+++ b/src/main/java/org/pqca/Main.java
@@ -71,6 +71,11 @@ public class Main {
             MavenPackageFinderService packageFinder =
                     new MavenPackageFinderService(projectDirectory);
             for (Path p : packageFinder.findPackages()) {
+                Optional<PackageMetadata> metadata = packageFinder.getMetadata(p);
+                if (!metadata.isPresent()) {
+                    continue;
+                }
+
                 try {
                     Path packagePath = p.equals(projectDirectory.toPath()) ? p : p.getParent();
                     LOG.info("Package path is: {}", packagePath.toString());
@@ -90,7 +95,7 @@ public class Main {
 
                     final Bom bom = createCombinedBom(List.of(javaBom));
 
-                    writeBom(packageFinder.getMetadata(p), bom);
+                    writeBom(metadata, bom);
                 } catch (GeneratorException | CBOMWasEmpty | CouldNotWriteCBOMToOutput e) {
                     LOG.error(e.getMessage(), e);
                 }

--- a/src/main/java/org/pqca/Main.java
+++ b/src/main/java/org/pqca/Main.java
@@ -43,11 +43,11 @@ public class Main {
         final BomGenerator bomGenerator = new BomGenerator(projectDirectory);
 
         try {
-            Bom javaBom = bomGenerator.generateJavaBoms();
-            Bom pythonBom = bomGenerator.generatePythonBoms();
+            /*Bom javaBom = */ bomGenerator.generateJavaBoms();
+            /*Bom pythonBom = */ bomGenerator.generatePythonBoms();
 
-            Bom consolidatedBom = createCombinedBom(List.of(javaBom, pythonBom));
-            bomGenerator.writeBom(consolidatedBom);
+            // Bom consolidatedBom = createCombinedBom(List.of(javaBom, pythonBom));
+            // bomGenerator.writeBom(consolidatedBom);
         } catch (CouldNotLoadJavaJars e) {
             LOG.error(e.getMessage(), e);
         }

--- a/src/main/java/org/pqca/Main.java
+++ b/src/main/java/org/pqca/Main.java
@@ -117,9 +117,7 @@ public class Main {
                                 pm ->
                                         String.format(
                                                 "cbom_%s_%s_%s.json",
-                                                pm.namespace(),
-                                                pm.name(),
-                                                pm.version()))
+                                                pm.namespace(), pm.name(), pm.version()))
                         .orElse("cbom.json");
 
         final BomJsonGenerator bomGenerator =

--- a/src/main/java/org/pqca/Main.java
+++ b/src/main/java/org/pqca/Main.java
@@ -25,7 +25,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
@@ -39,11 +38,6 @@ public class Main {
     private static final Logger LOG = LoggerFactory.getLogger(Main.class);
 
     public static void main(@Nonnull String[] args) {
-        Map<String, String> env = System.getenv();
-        for (String envName : env.keySet()) {
-            LOG.info("{}={}", envName, env.get(envName));
-        }
-
         final String workspace = System.getenv("GITHUB_WORKSPACE");
         final File projectDirectory = new File(workspace);
         final BomGenerator bomGenerator = new BomGenerator(projectDirectory);

--- a/src/main/java/org/pqca/Main.java
+++ b/src/main/java/org/pqca/Main.java
@@ -108,7 +108,6 @@ public class Main {
                                                 pm.name(),
                                                 pm.version()))
                         .orElse("cbom.json");
-        final String githubOutput = System.getenv("GITHUB_OUTPUT");
 
         final BomJsonGenerator bomGenerator =
                 BomGeneratorFactory.createJson(Version.VERSION_16, bom);
@@ -124,10 +123,6 @@ public class Main {
                 bom.getComponents() == null ? 0 : bom.getComponents().size());
         try (FileWriter writer = new FileWriter(fileName)) {
             writer.write(bomString);
-            // set output var
-            final FileWriter outPutVarFileWriter = new FileWriter(githubOutput, true);
-            outPutVarFileWriter.write("filename=" + fileName + "\n");
-            outPutVarFileWriter.close();
         } catch (IOException e) {
             throw new CouldNotWriteCBOMToOutput(e);
         }

--- a/src/main/java/org/pqca/Main.java
+++ b/src/main/java/org/pqca/Main.java
@@ -20,89 +20,36 @@
 package org.pqca;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.io.File;
-import java.io.FileFilter;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
-import org.cyclonedx.Version;
-import org.cyclonedx.exception.GeneratorException;
-import org.cyclonedx.generators.BomGeneratorFactory;
-import org.cyclonedx.generators.json.BomJsonGenerator;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
-import org.cyclonedx.model.Metadata;
-import org.cyclonedx.model.OrganizationalEntity;
-import org.cyclonedx.model.Service;
-import org.cyclonedx.model.metadata.ToolInformation;
-import org.pqca.errors.CBOMWasEmpty;
 import org.pqca.errors.CouldNotLoadJavaJars;
-import org.pqca.errors.CouldNotWriteCBOMToOutput;
-import org.pqca.indexing.JavaIndexService;
-import org.pqca.indexing.ProjectModule;
-import org.pqca.packages.MavenPackageFinderService;
-import org.pqca.packages.PackageMetadata;
-import org.pqca.scanning.java.JavaScannerService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("java:S106")
 public class Main {
     private static final Logger LOG = LoggerFactory.getLogger(Main.class);
-    private static final String ACTION_NAME = "CBOMkit-action";
-    private static final String ACTION_ORG = "PQCA";
 
     public static void main(@Nonnull String[] args) {
         final String workspace = System.getenv("GITHUB_WORKSPACE");
         final File projectDirectory = new File(workspace);
+        final BomGenerator bomGenerator = new BomGenerator(projectDirectory);
 
         try {
-            final List<File> javaJars = getJavaJars();
-            final JavaIndexService javaIndexService = new JavaIndexService(projectDirectory);
+            Bom javaBom = bomGenerator.generateJavaBoms();
+            Bom pythonBom = bomGenerator.generatePythonBoms();
 
-            // identify packages
-            MavenPackageFinderService packageFinder =
-                    new MavenPackageFinderService(projectDirectory);
-            for (Path p : packageFinder.findPackages()) {
-                Optional<PackageMetadata> metadata = packageFinder.getMetadata(p);
-                if (!metadata.isPresent()) {
-                    continue;
-                }
-
-                try {
-                    Path packagePath = p.equals(projectDirectory.toPath()) ? p : p.getParent();
-                    LOG.info("Package path is: {}", packagePath.toString());
-
-                    // java
-                    final List<ProjectModule> javaProjectModules =
-                            javaIndexService.index(packagePath);
-                    if (javaProjectModules.isEmpty()) {
-                        LOG.info("Skipping - no projects found");
-                        continue;
-                    }
-                    final JavaScannerService javaScannerService =
-                            new JavaScannerService(javaJars, packagePath.toFile());
-                    final Bom javaBom = javaScannerService.scan(null, javaProjectModules);
-
-                    // TODO: python
-
-                    final Bom bom = createCombinedBom(List.of(javaBom));
-
-                    writeBom(metadata, bom);
-                } catch (GeneratorException | CBOMWasEmpty | CouldNotWriteCBOMToOutput e) {
-                    LOG.error(e.getMessage(), e);
-                }
-            }
+            Bom consolidatedBom = createCombinedBom(List.of(javaBom, pythonBom));
+            bomGenerator.writeBom(consolidatedBom);
         } catch (CouldNotLoadJavaJars e) {
             LOG.error(e.getMessage(), e);
-            return;
         }
 
         // set output var
@@ -114,54 +61,10 @@ public class Main {
         }
     }
 
-    private static void writeBom(Optional<PackageMetadata> packageMetadata, Bom bom)
-            throws GeneratorException, CouldNotWriteCBOMToOutput, CBOMWasEmpty {
-        final String fileName =
-                packageMetadata
-                        .map(
-                                pm ->
-                                        String.format(
-                                                "cbom_%s_%s_%s.json",
-                                                pm.namespace(), pm.name(), pm.version()))
-                        .orElse("cbom.json");
-
-        final BomJsonGenerator bomGenerator =
-                BomGeneratorFactory.createJson(Version.VERSION_16, bom);
-        @Nullable String bomString = bomGenerator.toJsonString();
-        // LOG.info(bomString);
-        if (bomString == null) {
-            throw new CBOMWasEmpty();
-        }
-
-        LOG.info(
-                "Writing cbom {} with {} components",
-                fileName,
-                bom.getComponents() == null ? 0 : bom.getComponents().size());
-        try (FileWriter writer = new FileWriter(fileName)) {
-            writer.write(bomString);
-        } catch (IOException e) {
-            throw new CouldNotWriteCBOMToOutput(e);
-        }
-    }
-
     @Nonnull
     private static Bom createCombinedBom(@Nonnull List<Bom> sourceBoms) {
         final Bom bom = new Bom();
         bom.setSerialNumber("urn:uuid:" + UUID.randomUUID());
-
-        final Metadata metadata = new Metadata();
-        metadata.setTimestamp(new Date());
-
-        final ToolInformation scannerInfo = new ToolInformation();
-        final Service scannerService = new Service();
-        scannerService.setName(ACTION_NAME);
-
-        final OrganizationalEntity organization = new OrganizationalEntity();
-        organization.setName(ACTION_ORG);
-        scannerService.setProvider(organization);
-        scannerInfo.setServices(List.of(scannerService));
-        metadata.setToolChoice(scannerInfo);
-        bom.setMetadata(metadata);
 
         final List<Component> components = new ArrayList<>();
         final List<Dependency> dependencies = new ArrayList<>();
@@ -172,19 +75,5 @@ public class Main {
         bom.setComponents(components);
         bom.setDependencies(dependencies);
         return bom;
-    }
-
-    @Nonnull
-    private static List<File> getJavaJars() throws CouldNotLoadJavaJars {
-        final String directoryPath = System.getenv("CBOMKIT_JAVA_JAR_DIR");
-        final File directory = new File(directoryPath);
-        final FileFilter jarFilter =
-                file -> file.isFile() && file.getName().toLowerCase().endsWith(".jar");
-        final File[] jars = directory.listFiles(jarFilter);
-        if (jars == null || jars.length == 0) {
-            throw new CouldNotLoadJavaJars(directory.toPath());
-        }
-        LOG.info("Loaded {} jars", jars.length);
-        return List.of(jars);
     }
 }

--- a/src/main/java/org/pqca/errors/CouldNotLoadJavaJars.java
+++ b/src/main/java/org/pqca/errors/CouldNotLoadJavaJars.java
@@ -20,10 +20,10 @@
 package org.pqca.errors;
 
 import jakarta.annotation.Nonnull;
-import java.nio.file.Path;
+import java.io.File;
 
 public class CouldNotLoadJavaJars extends Exception {
-    public CouldNotLoadJavaJars(@Nonnull Path path) {
-        super("Couldn't load Java jars from " + path);
+    public CouldNotLoadJavaJars(@Nonnull File dir) {
+        super("Couldn't load Java jars from " + dir);
     }
 }

--- a/src/main/java/org/pqca/indexing/IndexingService.java
+++ b/src/main/java/org/pqca/indexing/IndexingService.java
@@ -23,16 +23,13 @@ import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.InputFile;
@@ -55,9 +52,7 @@ public abstract class IndexingService {
     }
 
     @Nonnull
-    public List<ProjectModule> index(@Nullable Path packageFolder) {
-        Optional.ofNullable(packageFolder)
-                .ifPresent(path -> baseDirectory = baseDirectory.toPath().resolve(path).toFile());
+    public List<ProjectModule> index() {
         return detectModules(baseDirectory, new ArrayList<>());
     }
 
@@ -69,7 +64,7 @@ public abstract class IndexingService {
         }
 
         if (isModule(filesInDir)) {
-            LOGGER.debug("Extracting projects from module: {}", projectDirectory.getPath());
+            LOGGER.debug("Extracting projects from module: {}", projectDirectory);
             for (File file : filesInDir) {
                 if (file.isDirectory()
                         && !".git".equals(file.getName())
@@ -97,7 +92,7 @@ public abstract class IndexingService {
         if (filesInDir == null) {
             return Collections.emptyList();
         }
-        LOGGER.debug("Extracting files from directory: {}", directory.getPath());
+        LOGGER.debug("Extracting files from directory: {}", directory);
 
         for (File file : filesInDir) {
             if (excludeFromIndexing(file)) {
@@ -106,7 +101,7 @@ public abstract class IndexingService {
             if (file.isDirectory() && !".git".equals(file.getName())) {
                 getFiles(new File(directory + File.separator + file.getName()), inputFiles);
             } else if (file.isFile() && file.getName().endsWith(this.languageFileExtension)) {
-                LOGGER.debug("Found file: {}", file.getPath());
+                LOGGER.debug("Found file: {}", file);
                 try {
                     TestInputFileBuilder builder = createTestFileBuilder(directory, file);
                     builder.setLanguage(this.languageIdentifier);
@@ -134,7 +129,7 @@ public abstract class IndexingService {
             }
         }
         if (contents == null || encoding == null) {
-            throw new IOException(String.format("Invalid encoding of file {}", file.getPath()));
+            throw new IOException(String.format("Invalid encoding of file {}", file));
         }
 
         return new TestInputFileBuilder("", file.getPath())

--- a/src/main/java/org/pqca/indexing/JavaIndexService.java
+++ b/src/main/java/org/pqca/indexing/JavaIndexService.java
@@ -31,12 +31,7 @@ public final class JavaIndexService extends IndexingService {
 
     @Override
     boolean isModule(@Nonnull File[] files) {
-        return Arrays.stream(files)
-                .anyMatch(
-                        f ->
-                                f.getName().equals("pom.xml")
-                                        || f.getName().equals("build.gradle")
-                                        || f.getName().equals("build.gradle.kts"));
+        return Arrays.stream(files).anyMatch(f -> f.getName().equals("pom.xml"));
     }
 
     @Override

--- a/src/main/java/org/pqca/packages/MavenPackageFinderService.java
+++ b/src/main/java/org/pqca/packages/MavenPackageFinderService.java
@@ -1,0 +1,71 @@
+/*
+ * CBOMkit-action
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pqca.packages;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.File;
+import java.io.FileReader;
+import java.nio.file.Path;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Parent;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+
+public class MavenPackageFinderService extends PackageFinderService {
+    @Nonnull private final MavenXpp3Reader reader;
+
+    public MavenPackageFinderService(@Nonnull File rootFile) throws IllegalArgumentException {
+        super(rootFile);
+        this.reader = new MavenXpp3Reader();
+    }
+
+    @Override
+    public boolean isBuildFile(@Nonnull Path file) {
+        return file.endsWith("pom.xml");
+    }
+
+    @Override
+    @Nullable public PackageMetadata getMetadata(@Nonnull Path buildFile) {
+        try {
+            final Model model = reader.read(new FileReader(buildFile.toFile()));
+            final String artifactId = model.getArtifactId();
+            if (!artifactId.endsWith("-parent")) {
+                String groupId = null;
+                String version = null;
+                Parent parent = model.getParent();
+                if (parent != null) {
+                    groupId = parent.getGroupId();
+                    version = parent.getVersion();
+                }
+                if (model.getGroupId() != null) {
+                    groupId = model.getGroupId();
+                }
+                if (model.getVersion() != null) {
+                    version = model.getVersion();
+                }
+                return new PackageMetadata(
+                        buildFile.getParent().toFile(), groupId, artifactId, version);
+            }
+        } catch (Exception e) {
+            // nothing
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/pqca/packages/PackageFinderService.java
+++ b/src/main/java/org/pqca/packages/PackageFinderService.java
@@ -1,0 +1,63 @@
+/*
+ * CBOMkit-action
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pqca.packages;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class PackageFinderService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PackageFinderService.class);
+
+    protected Path root;
+
+    protected PackageFinderService(@Nonnull File rootFile) throws IllegalArgumentException {
+        if (!rootFile.isDirectory()) {
+            throw new IllegalArgumentException("Path must be a directory!");
+        }
+        this.root = rootFile.toPath();
+    }
+
+    @Nonnull
+    public List<PackageMetadata> findPackages() {
+        try (Stream<Path> walk = Files.walk(this.root)) {
+            return walk.filter(p -> !Files.isDirectory(p))
+                    .filter(this::isBuildFile)
+                    .map(this::getMetadata)
+                    .filter(Objects::nonNull)
+                    .toList();
+        } catch (Exception e) {
+            LOGGER.error("Failed to find packages: {}", e.getMessage());
+        }
+        return Collections.emptyList();
+    }
+
+    public abstract boolean isBuildFile(@Nonnull Path file);
+
+    @Nullable public abstract PackageMetadata getMetadata(@Nonnull Path buildFile);
+}

--- a/src/main/java/org/pqca/packages/PackageMetadata.java
+++ b/src/main/java/org/pqca/packages/PackageMetadata.java
@@ -1,0 +1,44 @@
+/*
+ * CBOMkit-action
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pqca.packages;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.File;
+
+public record PackageMetadata(
+        @Nonnull File packageDir,
+        @Nullable String namespace,
+        @Nonnull String name,
+        @Nullable String version) {
+
+    public String getCbomFileName() {
+        StringBuilder sb = new StringBuilder("cbom");
+        if (namespace != null) {
+            sb.append("_" + namespace);
+        }
+        sb.append("_" + name);
+        if (version != null) {
+            sb.append("_" + version);
+        }
+        sb.append(".json");
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/pqca/packages/PackageMetadata.java
+++ b/src/main/java/org/pqca/packages/PackageMetadata.java
@@ -34,7 +34,9 @@ public record PackageMetadata(
         if (namespace != null) {
             sb.append("_" + namespace);
         }
-        sb.append("_" + name);
+        if (name != null) {
+            sb.append("_" + name);
+        }
         if (version != null) {
             sb.append("_" + version);
         }

--- a/src/main/java/org/pqca/packages/PythonPackageFinderService.java
+++ b/src/main/java/org/pqca/packages/PythonPackageFinderService.java
@@ -1,0 +1,93 @@
+/*
+ * CBOMkit-action
+ * Copyright (C) 2025 PQCA
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pqca.packages;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.tomlj.Toml;
+import org.tomlj.TomlParseResult;
+
+public class PythonPackageFinderService extends PackageFinderService {
+
+    private static final Pattern NAME_PATTERN = Pattern.compile("name\\s*=\\s*['\"]([^'\"]*)['\"]");
+    private static final Pattern VERSION_PATTERN =
+            Pattern.compile("version\\s*=\\s*['\"]([^'\"]*)['\"]");
+
+    public PythonPackageFinderService(@Nonnull File rootFile) throws IllegalArgumentException {
+        super(rootFile);
+    }
+
+    @Override
+    public boolean isBuildFile(@Nonnull Path file) {
+        return file.endsWith("pyproject.toml")
+                || file.endsWith("setup.cfg")
+                || file.endsWith("setup.py");
+    }
+
+    @Override
+    @Nullable public PackageMetadata getMetadata(@Nonnull Path buildFile) {
+        try {
+            if (buildFile.endsWith("pyproject.toml")) {
+                TomlParseResult result = Toml.parse(buildFile);
+                final String name = result.getString("project.name");
+                if (name != null) {
+                    return new PackageMetadata(
+                            buildFile.getParent().toFile(),
+                            null,
+                            name,
+                            result.getString("project.version"));
+                }
+            } else if (buildFile.endsWith("setup.cfg") || buildFile.endsWith("setup.py")) {
+                final String name = findAttribute(NAME_PATTERN, buildFile);
+                if (name != null) {
+                    return new PackageMetadata(
+                            buildFile.getParent().toFile(),
+                            null,
+                            name,
+                            findAttribute(VERSION_PATTERN, buildFile));
+                }
+            }
+        } catch (Exception e) {
+            // nothing
+        }
+        return null;
+    }
+
+    @Nullable private String findAttribute(@Nonnull Pattern pattern, @Nonnull Path buildFile)
+            throws Exception {
+        try (BufferedReader reader = new BufferedReader(new FileReader(buildFile.toFile()))) {
+            String line;
+
+            while ((line = reader.readLine()) != null) {
+                final Matcher matcher = pattern.matcher(line);
+                if (matcher.find()) {
+                    return matcher.group(1);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/pqca/scanning/IScannerService.java
+++ b/src/main/java/org/pqca/scanning/IScannerService.java
@@ -21,8 +21,6 @@ package org.pqca.scanning;
 
 import com.ibm.mapper.model.INode;
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
-import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Consumer;
 import org.cyclonedx.model.Bom;
@@ -31,5 +29,5 @@ import org.pqca.indexing.ProjectModule;
 public interface IScannerService extends Consumer<List<INode>> {
 
     @Nonnull
-    Bom scan(@Nullable Path packageFolder, @Nonnull List<ProjectModule> index) throws Exception;
+    Bom scan(@Nonnull List<ProjectModule> index) throws Exception;
 }

--- a/src/main/java/org/pqca/scanning/java/JavaScannerService.java
+++ b/src/main/java/org/pqca/scanning/java/JavaScannerService.java
@@ -68,6 +68,7 @@ public final class JavaScannerService extends ScannerService {
         sonarComponents.setSensorContext(sensorContext);
 
         LOGGER.info("Start scanning {} java projects", index.size());
+        index.forEach(pm -> LOGGER.info("  " + pm.identifier()));
 
         for (ProjectModule project : index) {
             final JavaAstScannerExtension jscanner = new JavaAstScannerExtension(sonarComponents);

--- a/src/main/java/org/pqca/scanning/java/JavaScannerService.java
+++ b/src/main/java/org/pqca/scanning/java/JavaScannerService.java
@@ -20,9 +20,7 @@
 package org.pqca.scanning.java;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.io.File;
-import java.nio.file.Path;
 import java.util.List;
 import org.cyclonedx.model.Bom;
 import org.pqca.indexing.ProjectModule;
@@ -52,7 +50,7 @@ public final class JavaScannerService extends ScannerService {
 
     @Override
     @Nonnull
-    public synchronized Bom scan(@Nullable Path packageFolder, @Nonnull List<ProjectModule> index) {
+    public synchronized Bom scan(@Nonnull List<ProjectModule> index) {
         final List<JavaCheck> visitors = List.of(new JavaDetectionCollectionRule(this));
         final SensorContextTester sensorContext = SensorContextTester.create(projectDirectory);
         sensorContext.setSettings(

--- a/src/main/java/org/pqca/scanning/python/PythonScannerService.java
+++ b/src/main/java/org/pqca/scanning/python/PythonScannerService.java
@@ -20,9 +20,7 @@
 package org.pqca.scanning.python;
 
 import jakarta.annotation.Nonnull;
-import jakarta.annotation.Nullable;
 import java.io.File;
-import java.nio.file.Path;
 import java.util.List;
 import org.cyclonedx.model.Bom;
 import org.pqca.indexing.ProjectModule;
@@ -39,7 +37,7 @@ public final class PythonScannerService extends ScannerService {
     }
 
     @Override
-    public @Nonnull Bom scan(@Nullable Path packageFolder, @Nonnull List<ProjectModule> index) {
+    public @Nonnull Bom scan(@Nonnull List<ProjectModule> index) {
         final PythonCheck visitor = new PythonDetectionCollectionRule(this);
 
         for (ProjectModule project : index) {


### PR DESCRIPTION
Implements additional features:
- Scans python code (#1 )
- Produces multiple CBOMs (#2):
     - One CBOM per maven/python package named `cbom[_<group_id>]_<artifact_id>_<version>.json`.
     - One consolidated CBOM over all source code named `cbom.json`
     - All CBOMs uploaded to github asset space via action variable `pattern=cbom*.json`
- Includes `giturl`, `branch`, `commit hash` and `subfolder` in metadata properties of each CBOM
-> CBOM files can be loaded into CbomKit, links to source code work correctly 