### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+*  @PQCA/cbomkit-maintainers


### PR DESCRIPTION
This repo should have a CODEOWNERS that matches other repos.