### PR TITLE
Detect java classes and jars

### DIFF
--- a/src/main/java/org/pqca/indexing/JavaIndexService.java
+++ b/src/main/java/org/pqca/indexing/JavaIndexService.java
@@ -67,6 +67,6 @@ public final class JavaIndexService extends IndexingService {
 
     @Override
     boolean excludeFromIndexing(@Nonnull File file) {
-        return file.getPath().contains("src/test/java") || file.getName().contains("package-info");
+        return file.getPath().contains("src/test/") || file.getName().contains("package-info");
     }
 }

--- a/src/main/java/org/pqca/indexing/PythonIndexService.java
+++ b/src/main/java/org/pqca/indexing/PythonIndexService.java
@@ -63,6 +63,6 @@ public final class PythonIndexService extends IndexingService {
 
     @Override
     boolean excludeFromIndexing(@Nonnull File file) {
-        return file.getPath().contains("tests/");
+        return file.getPath().contains("tests/") || file.getPath().contains("src/test/");
     }
 }

--- a/src/main/java/org/pqca/scanning/java/JavaScannerService.java
+++ b/src/main/java/org/pqca/scanning/java/JavaScannerService.java
@@ -21,10 +21,16 @@ package org.pqca.scanning.java;
 
 import jakarta.annotation.Nonnull;
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 import org.cyclonedx.model.Bom;
 import org.pqca.indexing.ProjectModule;
 import org.pqca.scanning.ScannerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.internal.DefaultFileSystem;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
@@ -40,31 +46,43 @@ import org.sonar.plugins.java.api.JavaResourceLocator;
 import org.sonar.plugins.java.api.JavaVersion;
 
 public final class JavaScannerService extends ScannerService {
+    private static final Logger LOG = LoggerFactory.getLogger(JavaScannerService.class);
+
     private static final JavaVersion JAVA_VERSION =
             new JavaVersionImpl(JavaVersionImpl.MAX_SUPPORTED);
 
-    @Nonnull private final String javaDependencyJARSPath;
-    @Nonnull private final List<String> targetClassDirectories;
+    @Nonnull private final String javaDependencyJars;
+    @Nonnull private final String targetClassDirectories;
 
-    public JavaScannerService(
-            @Nonnull String javaDependencyJARSPath,
-            @Nonnull List<String> targetClassDirectories,
-            @Nonnull File projectDirectory) {
+    public JavaScannerService(@Nonnull File projectDirectory) {
         super(projectDirectory);
-        this.javaDependencyJARSPath = javaDependencyJARSPath;
-        this.targetClassDirectories = targetClassDirectories;
+
+        this.javaDependencyJars = getJavaDependencyJARs();
+        this.targetClassDirectories = getJavaClassDirPatterns();
+
+        String requireBuildStr = System.getenv("CBOMKIT_JAVA_REQUIRE_BUILD");
+        boolean requireBuild = requireBuildStr != null ? Boolean.valueOf(requireBuildStr) : true;
+        if (!projectIsBuilt()) {
+            if (requireBuild) {
+                throw new IllegalStateException(
+                        "No Java build artifacts found. Propject must be build prior to scanning");
+            } else {
+                LOG.warn(
+                        "No Java build artifacts found. Scanning Java code without prior build may produce less accurate CBOMs.");
+            }
+        }
     }
 
     @Override
     @Nonnull
     public synchronized Bom scan(@Nonnull List<ProjectModule> index) {
-        final SensorContextTester sensorContext = SensorContextTester.create(this.projectDirectory);
+        final SensorContextTester sensorContext = SensorContextTester.create(projectDirectory);
         sensorContext.setSettings(
                 new MapSettings()
                         .setProperty(SonarComponents.SONAR_BATCH_MODE_KEY, true)
-                        .setProperty("sonar.java.libraries", this.javaDependencyJARSPath)
-                        .setProperty(
-                                "sonar.java.binaries", String.join(",", targetClassDirectories))
+                        // .setProperty("sonar.java.jdkHome", System.getProperty("java.home"))
+                        .setProperty("sonar.java.libraries", javaDependencyJars)
+                        .setProperty("sonar.java.binaries", targetClassDirectories)
                         .setProperty(SonarComponents.SONAR_AUTOSCAN, false)
                         .setProperty(SonarComponents.SONAR_BATCH_SIZE_KEY, 8 * 1024 * 1024));
         final DefaultFileSystem fileSystem = sensorContext.fileSystem();
@@ -132,5 +150,64 @@ public final class JavaScannerService extends ScannerService {
                 classpathForTest,
                 null,
                 null);
+    }
+
+    private String getJavaDependencyJARs() {
+        String javaDependencyJars = System.getenv("CBOMKIT_JAVA_JARS");
+        if (javaDependencyJars != null) {
+            LOG.info("CBOMKIT_JAVA_JARS: {}", javaDependencyJars);
+            return javaDependencyJars;
+        }
+
+        List<String> jars = new ArrayList<String>();
+        addJarPattern(jars, projectDirectory.getAbsolutePath());
+        addJarPattern(jars, System.getProperty("user.home") + "/.m2/repository");
+        addJarPattern(jars, System.getProperty("user.home") + "/.gradle");
+        addJarPattern(jars, System.getenv("CBOMKIT_JAVA_JAR_DIR"));
+
+        LOG.info("CBOMKIT_JAVA_JARS not set. Default pattern: {}", jars);
+        return String.join(",", jars);
+    }
+
+    private static void addJarPattern(List<String> jarPatterns, String dir) {
+        try {
+            File javaJarDir = (new File(dir)).getCanonicalFile();
+            if (!javaJarDir.exists() || !javaJarDir.isDirectory()) {
+                LOG.warn("Jar directory does not exists: {}", javaJarDir);
+                return;
+            }
+
+            jarPatterns.add(javaJarDir.getAbsolutePath() + "/**/*.jar");
+            jarPatterns.add(javaJarDir.getAbsolutePath() + "/**/*.zip");
+        } catch (Exception e) {
+            LOG.error("Failed to contruct jar pattern from {}", dir);
+        }
+    }
+
+    private String getJavaClassDirPatterns() {
+        String javaClasses = System.getenv("CBOMKIT_JAVA_CLASSES");
+        if (javaClasses != null) {
+            LOG.info("CBOMKIT_JAVA_CLASSES: {}", javaClasses);
+            return javaClasses;
+        }
+
+        try {
+            javaClasses =
+                    this.projectDirectory.getCanonicalFile().getAbsolutePath() + "/**/classes";
+            LOG.info("CBOMKIT_JAVA_CLASSES not set. Default pattern: {}", javaClasses);
+            return javaClasses;
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    private boolean projectIsBuilt() {
+        try (Stream<Path> walk = Files.walk(this.projectDirectory.toPath())) {
+            return !walk.filter(p -> p.endsWith("classes") && Files.isDirectory(p))
+                    .toList().isEmpty();
+        } catch (Exception e) {
+            LOG.error(e.getMessage());
+            return false;
+        }
     }
 }


### PR DESCRIPTION
- Java jars can be specified via `CBOMKIT_JAVA_JARS`. Variable takes a comma-separates list of jar or zip files. Glob patterns are supported.
    - If specified value is passed as is to `sonar.java.libraries` (absolute paths should be used).
    - If not specified, pattern is constructed  from `~/.m2/repository` (if existing), `~/.gradle` (if existing), `GITHUB_WORKSPACE` and the bc jars in `CBOMKIT_JAVA_JAR_DIR` which is set in the base image.
- Java classes dirs can be specified via `CBOMKIT_JAVA_CLASSES`. Variable takes a comma-separates list of strings (directories). Glob patterns are supported.
    - If specified value is passed as is to `sonar.java.binaries` (absolute paths should be used).
    - If not specified pattern is set to default value `GITHUB_WORKSPACE/**/classes`.
- Check if the project was built prior to scanning. This is done by searching for dirs that match the `CBOMKIT_JAVA_CLASSES` default pattern. If project was not built a runtime exception is thrown and the scan fails. This behavior can be changed by setting `CBOMKIT_JAVA_REQUIRE_BUILD` to `false` (default is `true`) which will only issue a warning and allows scanning just the source code.
- Fix for issue #13:
    - Java indexing excludes all file in `src/test` plus `package-info.java` files.
    - Python indexing excludes all files in `tests` and `src/test`. 