### PR TITLE
added configuration options

### DIFF
--- a/src/main/java/org/pqca/scanning/java/JavaScannerService.java
+++ b/src/main/java/org/pqca/scanning/java/JavaScannerService.java
@@ -204,7 +204,8 @@ public final class JavaScannerService extends ScannerService {
     private boolean projectIsBuilt() {
         try (Stream<Path> walk = Files.walk(this.projectDirectory.toPath())) {
             return !walk.filter(p -> p.endsWith("classes") && Files.isDirectory(p))
-                    .toList().isEmpty();
+                    .toList()
+                    .isEmpty();
         } catch (Exception e) {
             LOG.error(e.getMessage());
             return false;


### PR DESCRIPTION
CBOMKit action behaviour can be configured via environment variables.

**Scanning options**
- CBOMKIT_OUTPUT_DIR: Optional output dir for CBOM files. Defaults to "cbom" if not set. 
- CBOMKIT_GENERATE_MODULE_CBOMS: Optional, default is true. If set, individual module CBOMs will be written
- CBOMKIT_WRITE_EMTPY_CBOMS: Optional, default is true. If set, CBOM files with 0 findings will be written. 
- CBOMKIT_LANGUAGES: Optional. Comma-separated list of programming languages. If set only files in specified languages will be scanned. If not set or empty all languages will be scanned.
- CBOMKIT_JAVA_REQUIRE_BUILD: Optional, default is true. Scan terminates with error if java project was not built before. Allows only-source scan if set to false.
- CBOMKIT_JAVA_JARS, Comma separated list of jar/zip files. Glob pattens allowed. Auto-constructed if not set. 
- CBOMKIT_JAVA_JAR_DIR : Directory containing additional jars (e.g. bouncy castle).
- CBOMKIT_JAVA_CLASSES: Comma-separated list of directories containing compiled class files. Glob pattens allowed. Auto-constructed if not set.

**Set by checkout action if run in workflow**
- GITHUB_WORKSPACE: Mandatory repo root directory. 
- GITHUB_OUTPUT: Optional, set by default in action workflow. Filename containing the name pattern of the CBOM files used by uploader
- GITHUB_SERVER_URL: Optional Github server: gitUrl metadata property = GITHUB_SERVER_URL + "/" + GITHUB_REPOSITORY.
- GITHUB_REPOSITORY: Optional Github repository name: gitUrl metadata property = GITHUB_SERVER_URL + "/" + GITHUB_REPOSITORY. 
- GITHUB_REF_NAME: Optional Github ref name: revision (branch) metadata property = GITHUB_REF_NAME.
- GITHUB_SHA: Github commit sha: commit metadata property = first 7 characters of GITHUB_SHA.
